### PR TITLE
Override lang index if key available in settings

### DIFF
--- a/Application/RSBot/Views/SplashScreen.cs
+++ b/Application/RSBot/Views/SplashScreen.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.ComponentModel;
 using System.Drawing;
 using System.IO;
@@ -218,7 +218,7 @@ public partial class SplashScreen : UIWindow
             return;
         }
 
-        Game.ReferenceManager.Load(GlobalConfig.Get("RSBot.TranslationIndex", 9), referenceDataLoader);
+        Game.ReferenceManager.Load(GlobalConfig.Get("RSBot.TranslationIndex", -1), referenceDataLoader);
     }
 
     private void referenceDataLoader_ProgressChanged(object sender, ProgressChangedEventArgs e)

--- a/Library/RSBot.Core/Client/ReferenceObjects/RefText.cs
+++ b/Library/RSBot.Core/Client/ReferenceObjects/RefText.cs
@@ -1,4 +1,4 @@
-﻿namespace RSBot.Core.Client.ReferenceObjects;
+namespace RSBot.Core.Client.ReferenceObjects;
 
 public class RefText : IReference<string>
 {
@@ -60,6 +60,10 @@ public class RefText : IReference<string>
 
         if (Game.ClientType == GameClientType.Japanese)
             languageTab = 9;
+
+        // Override if custom translation index is set
+        if (Game.ReferenceManager.LanguageTab >= 0)
+            languageTab = Game.ReferenceManager.LanguageTab;
 
         var maxTabs = parser.GetColumnCount();
 


### PR DESCRIPTION
Allows the user to select which language files the bot should use. Also paves a way for solving the indexes that aren't in the general order.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Translation and reference data loading now respects custom configuration settings, providing greater flexibility in how language resources are initialized during application startup.
  * System can now use configurable translation indices when loading reference text data, improving support for varied language configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->