### PR TITLE
Fixed party disbandment when the server is shut down & spawn parsing

### DIFF
--- a/Library/RSBot.Core/Network/Handler/Agent/Party/PartyUpdateResponse.cs
+++ b/Library/RSBot.Core/Network/Handler/Agent/Party/PartyUpdateResponse.cs
@@ -38,7 +38,6 @@ internal class PartyUpdateResponse : IPacketHandler
         switch (type)
         {
             case PartyUpdateType.Dismissed:
-                Game.Party.Clear();
                 EventManager.FireEvent("OnPartyDismiss");
                 break;
 
@@ -61,7 +60,6 @@ internal class PartyUpdateResponse : IPacketHandler
                 else if (memberLeft.Name == Game.Player.Name)
                 {
                     EventManager.FireEvent("OnPartyDismiss");
-                    Game.Party.Clear();
                 }
                 else
                 {

--- a/Library/RSBot.Core/Objects/Party/Party.cs
+++ b/Library/RSBot.Core/Objects/Party/Party.cs
@@ -118,7 +118,7 @@ public class Party
     /// <summary>
     ///     Clears this instance.
     /// </summary>
-    internal void Clear()
+    public void Clear()
     {
         Members = null;
         Leader = null;

--- a/Library/RSBot.Core/Objects/Spawn/SpawnedPlayer.cs
+++ b/Library/RSBot.Core/Objects/Spawn/SpawnedPlayer.cs
@@ -285,7 +285,7 @@ public sealed class SpawnedPlayer : SpawnedBionic
         Name = packet.ReadString();
         Job = (JobType)packet.ReadByte();
 
-        if (Game.ClientType >= GameClientType.Chinese_Old && WearsJobSuite)
+        if (Game.ClientType >= GameClientType.Vietnam274 && WearsJobSuite)
             if (WearsJobSuite)
             {
                 packet.ReadByte(); // JobRank
@@ -293,7 +293,7 @@ public sealed class SpawnedPlayer : SpawnedBionic
                 packet.ReadByte(); // ??
             }
 
-        if (Game.ClientType < GameClientType.Chinese_Old)
+        if (Game.ClientType < GameClientType.Vietnam274)
         {
             JobLevel = packet.ReadByte();
             PvpState = (PvpState)packet.ReadByte();
@@ -308,7 +308,7 @@ public sealed class SpawnedPlayer : SpawnedBionic
         ScrollMode = (ScrollMode)packet.ReadByte();
         InteractMode = (InteractMode)packet.ReadByte();
 
-        if (Game.ClientType < GameClientType.Chinese_Old)
+        if (Game.ClientType < GameClientType.Vietnam274)
             packet.ReadByte(); //unkByte4
 
         var guildName = packet.ReadString();

--- a/Plugins/RSBot.Party/Views/Main.cs
+++ b/Plugins/RSBot.Party/Views/Main.cs
@@ -640,7 +640,7 @@ public partial class Main : DoubleBufferedControl
         menuLeave.Enabled = false;
         lblLeader.Text = LanguageManager.GetLang("NotInParty");
         listParty.Items.Clear();
-        Game.Party.Clear();
+        Game.Party?.Clear();
         Log.NotifyLang("PartyDismissed");
         OnDeletePartyEntry();
     }

--- a/Plugins/RSBot.Party/Views/Main.cs
+++ b/Plugins/RSBot.Party/Views/Main.cs
@@ -635,14 +635,12 @@ public partial class Main : DoubleBufferedControl
     /// </summary>
     public void OnPartyDismiss()
     {
-        //if (!Game.Ready)
-        //    return;
-
         Bundle.Container.PartyMatching.HasMatchingEntry = false;
         btnLeaveParty.Enabled = false;
         menuLeave.Enabled = false;
         lblLeader.Text = LanguageManager.GetLang("NotInParty");
         listParty.Items.Clear();
+        Game.Party.Clear();
         Log.NotifyLang("PartyDismissed");
         OnDeletePartyEntry();
     }


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Party dismissal now consistently resets party state and UI (clears members, updates leader label, disables leave controls).

* **Refactor**
  * Updated player spawn parsing to change which client versions receive additional job/rank and PvP information, improving accuracy of displayed player details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->