### PR TITLE
Fixes for buffing and party invites

### DIFF
--- a/Botbases/RSBot.Training/Bundle/Buff/BuffBundle.cs
+++ b/Botbases/RSBot.Training/Bundle/Buff/BuffBundle.cs
@@ -51,9 +51,9 @@ internal class BuffBundle : IBundle
                     //#377 bug detected!
                     Log.Notify($"[#377] The buff [{buff.Token}-{buff.Record?.GetRealName()}] expired");
 
-                    EventManager.FireEvent("OnRemoveBuff", buff);
+                    EventManager.FireEvent("OnRemoveBuff", info);
 
-                    var playerSkill = Game.Player.Skills.GetSkillInfoById(buff.Id);
+                    var playerSkill = Game.Player.Skills.GetSkillInfoById(info.Id);
                     playerSkill?.Reset();
                     Game.Player.State.TryRemoveActiveBuff(info.Token, out _);
                 }

--- a/Library/RSBot.Core/Components/SkillManager.cs
+++ b/Library/RSBot.Core/Components/SkillManager.cs
@@ -439,42 +439,64 @@ public static class SkillManager
             packet.WriteByte(ActionTarget.None);
         }
 
-        var asyncCallback = new AwaitCallback(
+        var castCallback = new AwaitCallback(
             response =>
             {
-                var targetId = response.ReadUInt();
-                var castedSkillId = response.ReadUInt();
+                var result = response.ReadByte();
 
-                if (targetId == (target == 0 ? Game.Player.UniqueId : target) && castedSkillId == skill.Id)
-                    return AwaitCallbackResult.Success;
+                if (result != 0x01)
+                    return AwaitCallbackResult.Fail;
 
-                return AwaitCallbackResult.ConditionFailed;
-            },
-            0xB0BD
-        );
+                var action = Objects.Action.DeserializeBegin(response);
 
-        var callback = new AwaitCallback(
-            response =>
-            {
-                return response.ReadByte() == 0x02 && response.ReadByte() == 0x00
+                return action.PlayerIsExecutor && action.SkillId == skill.Id
                     ? AwaitCallbackResult.Success
                     : AwaitCallbackResult.ConditionFailed;
+            },
+            0xB070
+        );
+
+        var actionStateCallback = new AwaitCallback(
+            response =>
+            {
+                var state = response.ReadByte();
+                var recurring = response.ReadByte();
+
+                if (state == 0x02 && recurring == 0x00)
+                    return AwaitCallbackResult.Success;
+
+                if (state == 0x03)
+                    return AwaitCallbackResult.Fail;
+
+                return AwaitCallbackResult.ConditionFailed;
             },
             0xB074
         );
 
-        PacketManager.SendPacket(packet, PacketDestination.Server, asyncCallback, callback);
+        if (!awaitBuffResponse)
+        {
+            PacketManager.SendPacket(packet, PacketDestination.Server);
+            return;
+        }
 
-        if (awaitBuffResponse)
-            asyncCallback.AwaitResponse(
-                skill.Record.Action_CastingTime
-                    + skill.Record.Action_ActionDuration
-                    + skill.Record.Action_PreparingTime
-                    + 1500
-            );
+        if (skill.Record.Basic_Activity != 1)
+            PacketManager.SendPacket(packet, PacketDestination.Server, castCallback, actionStateCallback);
+        else
+            PacketManager.SendPacket(packet, PacketDestination.Server, castCallback);
 
-        if (skill.Record.Basic_Activity != 1 && awaitBuffResponse)
-            callback.AwaitResponse();
+        var timeout =
+            skill.Record.Action_CastingTime
+            + skill.Record.Action_ActionDuration
+            + skill.Record.Action_PreparingTime
+            + 1500;
+
+        castCallback.AwaitResponse(timeout);
+
+        if (!castCallback.IsCompleted)
+            return;
+
+        if (skill.Record.Basic_Activity != 1)
+            actionStateCallback.AwaitResponse(timeout);
     }
 
     /// <summary>

--- a/Library/RSBot.Core/Network/Socket/Server.cs
+++ b/Library/RSBot.Core/Network/Socket/Server.cs
@@ -1,14 +1,17 @@
-﻿using System;
-using System.Net;
-using System.Net.Sockets;
-using RSBot.Core.Event;
+﻿using RSBot.Core.Event;
 using RSBot.Core.Extensions;
 using RSBot.Core.Network.Protocol;
+using System;
+using System.Net;
+using System.Net.Sockets;
 
 namespace RSBot.Core.Network;
 
 public class Server : NetBase
 {
+    private bool _receivedInitialHandshake;
+    private bool _receivedPostInitialHandshakePacket;
+
     /// <summary>
     ///     Gets or sets the ip.
     /// </summary>
@@ -42,6 +45,8 @@ public class Server : NetBase
         {
             _protocol = new SecurityProtocol();
             _socket = new Socket(AddressFamily.InterNetwork, SocketType.Stream, ProtocolType.Tcp);
+            _receivedInitialHandshake = false;
+            _receivedPostInitialHandshakePacket = false;
 
             try
             {
@@ -62,7 +67,7 @@ public class Server : NetBase
                 {
                     _socket.Connect(ip, port, 3000);
                 }
-            }
+                }
             catch (AggregateException s)
             {
                 Log.Error(s.Message);
@@ -111,26 +116,26 @@ public class Server : NetBase
         try
         {
             receivedSize = _socket.EndReceive(ar, out var error);
+            var rawOpcode = receivedSize >= 4 ? $"0x{BitConverter.ToUInt16(_buffer, 2):X4}" : "n/a";
+
             if (receivedSize == 0 || error != SocketError.Success)
             {
-                Log.Debug($"Socket closed: receivedSize={receivedSize}, error={error}");
-                if (_socket != null)
-                {
-                    try
-                    {
-                        Log.Debug($"Socket.Connected={_socket.Connected}, LocalEndPoint={_socket.LocalEndPoint}, RemoteEndPoint={_socket.RemoteEndPoint}");
-                    }
-                    catch { }
-                }
+                if (!IsClosing && EnablePacketDispatcher && _receivedInitialHandshake && !_receivedPostInitialHandshakePacket)
+                    Log.Notify("Gateway closed immediately after initial 0x5000 before handshake completed. Possible IP/session limit");
+
                 OnDisconnected();
                 return;
             }
+
+            if (!_receivedInitialHandshake && rawOpcode == "0x5000")
+                _receivedInitialHandshake = true;
+            else if (_receivedInitialHandshake)
+                _receivedPostInitialHandshakePacket = true;
 
             _protocol.Recv(_buffer, 0, receivedSize);
         }
         catch (SocketException se)
         {
-            Log.Debug($"SocketException: Code={se.SocketErrorCode}, NativeErrorCode={se.NativeErrorCode}, Message={se.Message}");
             if (se.SocketErrorCode == SocketError.ConnectionReset) //Client OnDisconnected > Mostly occurs during GW->AS switch
                 OnDisconnected();
         }
@@ -146,9 +151,8 @@ public class Server : NetBase
                 if (receivedSize != 0 && _socket != null && _socket.Connected)
                     _socket.BeginReceive(_buffer, 0, _buffer.Length, SocketFlags.None, OnBeginReceiveCallback, null);
             }
-            catch (Exception ex)
+            catch
             {
-                Log.Debug($"Exception in BeginReceive: {ex.Message}");
                 OnDisconnected();
             }
         }

--- a/Plugins/RSBot.Party/Bundle/AutoParty/AutoPartyBundle.cs
+++ b/Plugins/RSBot.Party/Bundle/AutoParty/AutoPartyBundle.cs
@@ -43,6 +43,16 @@ internal class AutoPartyBundle
     /// </value>
     public AutoPartyConfig Config { get; set; }
 
+    private void ApplyPartySettingsFromConfig()
+    {
+        if (!Game.Party.IsInParty)
+            Game.Party.Settings = new PartySettings(
+                Config.ExperienceAutoShare,
+                Config.ItemAutoShare,
+                Config.AllowInvitations
+            );
+    }
+
     /// <summary>
     ///     Refreshes this instance.
     /// </summary>
@@ -70,12 +80,7 @@ internal class AutoPartyBundle
             AlwaysFollowThePartyMaster = PlayerConfig.Get("RSBot.Party.AlwaysFollowPartyMaster", false),
         };
 
-        if (!Game.Party.IsInParty)
-            Game.Party.Settings = new PartySettings(
-                Config.ExperienceAutoShare,
-                Config.ItemAutoShare,
-                Config.AllowInvitations
-            );
+        ApplyPartySettingsFromConfig();
     }
 
     public void OnTick()
@@ -154,6 +159,9 @@ internal class AutoPartyBundle
     /// </summary>
     public void CheckForPlayers()
     {
+        if (Config == null)
+            return;
+
         if (
             Game.Party.IsInParty
             && !Game.Party.IsLeader
@@ -163,12 +171,7 @@ internal class AutoPartyBundle
             if (Config.LeaveIfMasterNotName != Game.Party.Leader.Name)
                 Game.Party.Leave();
 
-        if (!Game.Party.IsInParty)
-            Game.Party.Settings = new PartySettings(
-                Config.ExperienceAutoShare,
-                Config.ItemAutoShare,
-                Config.AllowInvitations
-            );
+        ApplyPartySettingsFromConfig();
 
         if (!Game.Party.CanInvite || Game.Party.Settings == null)
             return;

--- a/Plugins/RSBot.Party/Bundle/AutoParty/AutoPartyBundle.cs
+++ b/Plugins/RSBot.Party/Bundle/AutoParty/AutoPartyBundle.cs
@@ -163,6 +163,13 @@ internal class AutoPartyBundle
             if (Config.LeaveIfMasterNotName != Game.Party.Leader.Name)
                 Game.Party.Leave();
 
+        if (!Game.Party.IsInParty)
+            Game.Party.Settings = new PartySettings(
+                Config.ExperienceAutoShare,
+                Config.ItemAutoShare,
+                Config.AllowInvitations
+            );
+
         if (!Game.Party.CanInvite || Game.Party.Settings == null)
             return;
 

--- a/Plugins/RSBot.Skills/Views/Main.cs
+++ b/Plugins/RSBot.Skills/Views/Main.cs
@@ -519,7 +519,7 @@ public partial class Main : DoubleBufferedControl
                 var itemBuffInfo = listItem.Tag as SkillInfo;
                 if (
                     itemBuffInfo != null
-                    && itemBuffInfo.Id == removingBuff.Id
+                    /*&& itemBuffInfo.Id == removingBuff.Id*/
                     && itemBuffInfo.Token == removingBuff.Token
                 )
                 {


### PR DESCRIPTION
- Buffs and attack speed have been significantly increased by fixing the buffs' callback
- Fixed a bug that caused party settings to be reset when inviting players after the party was disbanded
- Added logging of the server closing the gateway connection before establishing a handshake

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Party auto-settings now initialize when the bot joins parties.

* **Bug Fixes**
  * Fixed buff removal to properly match buffs by identifier.
  * Improved connection handling to detect gateway disconnections during handshake.
  * Corrected expired buff handling to fire removal events properly.

* **Refactor**
  * Enhanced skill casting callback system for improved action-state validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->